### PR TITLE
[1.x] Improve test suite

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,10 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.0, 8.1 ]
-        dependencies: ['locked', 'lowest', 'highest']
+        dependencies: [ 'lowest', 'highest' ]
+        include:
+          - php: 8.2
+            composer-options: '--ignore-platform-reqs'
 
     name: PHP ${{ matrix.php }} -  ${{ matrix.dependencies }}
 
@@ -34,6 +37,18 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "${{ matrix.composer-options }}"
+
+      # - name: Cache dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ~/.composer/cache/files
+      #     key: ${{ runner.os }}-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+      #     restore-keys: ${{ runner.os }}-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
+
+      # - name: Install dependencies
+      #   run: |
+      #     composer update --${{ matrix.dependencies }} --prefer-dist --no-progress ${{ matrix.composer-options }}
 
       - name: Run Tests
         run: composer run-script test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,10 @@ jobs:
         include:
           - php: 8.2
             composer-options: '--ignore-platform-reqs'
-            dependencies: ['lowest', 'highest']
+            dependencies: 'lowest'
+          - php: 8.2
+            composer-options: '--ignore-platform-reqs'
+            dependencies: 'highest'
 
     name: PHP ${{ matrix.php }} -  ${{ matrix.dependencies }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,13 +12,9 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.0, 8.1 ]
-        laravel: [ 9.* ]
-        dependency-version: [ prefer-stable, prefer-lowest ]
-        include:
-          - laravel: 9.*
-            testbench: 7.*
+        dependencies: ['locked', 'lowest', 'highest']
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: PHP ${{ matrix.php }} -  ${{ matrix.dependencies }}
 
     steps:
       - name: Checkout
@@ -31,20 +27,16 @@ jobs:
           extensions: mbstring, intl
           coverage: xdebug
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
+      # Install dependencies and handle caching in one go.
+      # Dependencies need to be installed to make sure the PHPUnit classes are recognized.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
         with:
-          path: ~/.composer/cache/files
-          key: ${{ runner.os }}-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
-          restore-keys: ${{ runner.os }}-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
+          dependency-versions: "${{ matrix.dependencies }}"
 
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-progress --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
       - name: Run Tests
         run: composer run-script test
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,24 +35,12 @@ jobs:
           coverage: xdebug
 
       # Install dependencies and handle caching in one go.
-      # Dependencies need to be installed to make sure the PHPUnit classes are recognized.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      # @link https://github.com/ramsey/composer-install
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "${{ matrix.composer-options }}"
-
-      # - name: Cache dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ~/.composer/cache/files
-      #     key: ${{ runner.os }}-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
-      #     restore-keys: ${{ runner.os }}-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
-
-      # - name: Install dependencies
-      #   run: |
-      #     composer update --${{ matrix.dependencies }} --prefer-dist --no-progress ${{ matrix.composer-options }}
 
       - name: Run Tests
         run: composer run-script test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           - php: 8.2
             composer-options: '--ignore-platform-reqs'
+            dependencies: ['lowest', 'highest']
 
     name: PHP ${{ matrix.php }} -  ${{ matrix.dependencies }}
 

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
         "issues": "https://github.com/Laragear/TwoFactor/issues"
     },
     "require": {
-        "php" : ">=8.0.2",
+        "php": ">=8.0.2",
         "ext-openssl": "*",
-        "ext-json" : "*",
+        "ext-json": "*",
         "illuminate/auth": "9.*",
         "illuminate/http": "9.*",
         "illuminate/session": "9.*",
@@ -45,6 +45,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "7.*",
+        "laravel/framework": "9.*",
         "phpunit/phpunit": "^9.5",
         "mockery/mockery": "^1.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     },
     "require-dev": {
         "orchestra/testbench": "7.*",
-        "laravel/framework": "9.*",
         "phpunit/phpunit": "^9.5",
         "mockery/mockery": "^1.5",
         "jetbrains/phpstorm-attributes": "^1.0"


### PR DESCRIPTION
# Description

## Improve yaml for test runs.

- laravel/orchestra version are provided in the composer file (in require-dev).
- make use of https://github.com/ramsey/composer-install to manage the composer installation & cache.
- Now runs on 3 levels:
    - lowest : installs the lowest versions of Composer dependencies   
      (equivalent to running `composer update --prefer-lowest --prefer-stable`)
    - locked : installs the locked versions of Composer dependencies
      (equivalent to running `composer install`)
    - highest : installs the highest versions of Composer dependencies
      (equivalent to running `composer update`)