### PR TITLE
[1.x] Add phpstan static code analysis.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[*.neon]
+indent_size = 4
+indent_style = tab

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,46 @@
+name: PHPStan
+
+on:
+  # Run on all pushes and on all pull requests.
+  # Prevent the build from running when there are only irrelevant changes.
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  phpstan:
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [ 8.0, 8.1 ]
+
+    name: "PHP: ${{ matrix.php }} | PHPStan"
+
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push to the branch.
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@2.15.0
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: phpstan
+
+      # Install dependencies and handle caching in one go.
+      # Dependencies need to be installed to make sure the PHPUnit classes are recognized.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+
+      - name: Run PHPStan
+        run: composer run-script phpstan

--- a/composer.json
+++ b/composer.json
@@ -32,21 +32,32 @@
         "issues": "https://github.com/Laragear/TwoFactor/issues"
     },
     "require": {
-        "php" : ">=8.0.2",
+        "php": ">=8.0.2",
         "ext-openssl": "*",
-        "ext-json" : "*",
+        "ext-json": "*",
         "illuminate/auth": "9.*",
+        "illuminate/config": "9.*",
+        "illuminate/database": "9.*",
+        "illuminate/encryption": "9.*",
         "illuminate/http": "9.*",
         "illuminate/session": "9.*",
         "illuminate/support": "9.*",
-        "illuminate/config": "9.*",
-        "illuminate/database": "9.*",
-        "illuminate/encryption": "9.*"
+        "thecodingmachine/safe": "^2.2"
     },
     "require-dev": {
+        "ergebnis/phpstan-rules": "^1.0",
+        "laravel/framework": "9.*",
+        "mockery/mockery": "^1.5",
+        "nunomaduro/larastan": "^2.0",
         "orchestra/testbench": "7.*",
+        "phpstan/phpstan": "^1.7",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpstan/phpstan-strict-rules": "^1.3",
         "phpunit/phpunit": "^9.5",
-        "mockery/mockery": "^1.5"
+        "slam/phpstan-extensions": "^6.0",
+        "squizlabs/php_codesniffer": "^3.5",
+        "symplify/phpstan-rules": "^11.0",
+        "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "autoload": {
         "psr-4": {
@@ -56,12 +67,14 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests",
-            "App\\Http\\Controllers\\WebAuthn\\": "stubs/controllers"
+            "App\\Http\\Controllers\\WebAuthn\\": "stubs/controllers",
+            "Laragear\\WebAuthn\\PHPStan\\": "phpstan/"
         }
     },
     "scripts": {
         "test": "vendor/bin/phpunit --coverage-clover build/logs/clover.xml",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "phpstan": "vendor/bin/phpstan analyze"
     },
     "config": {
         "sort-packages": true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,45 @@
+includes:
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+	- vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/nunomaduro/larastan/extension.neon
+
+services:
+	-
+		class: Ergebnis\PHPStan\Rules\Expressions\NoErrorSuppressionRule
+		tags:
+			- phpstan.rules.rule
+	-
+		class: SlamPhpStan\UnusedVariableRule
+		tags:
+			- phpstan.rules.rule
+
+	-
+		class: Laragear\WebAuthn\PHPStan\Rules\DisallowedConstructs\DisallowedBooleanCastRule
+		tags:
+			- phpstan.rules.rule
+	-
+		class: Laragear\WebAuthn\PHPStan\Rules\DisallowedConstructs\DisallowedBooleanConversionRule
+		tags:
+			- phpstan.rules.rule
+
+parameters:
+	level: 7
+	reportMaybesInPropertyPhpDocTypes: false
+	checkMissingIterableValueType: false
+	checkGenericClassInNonGenericObjectType: false
+	featureToggles:
+		bleedingEdge: true
+	paths:
+		- src
+		- stubs
+
+	ignoreErrors:
+		# bunch of false positives from Eloquent
+		- '#Method .*::parseCredentials\(\) should .*Collection<.*> but returns .*Collection<.*>.#'
+		- '#Dynamic call to static method .*Builder<.*WebAuthnCredential>::exists\(\).#'
+		- '#Dynamic call to static method .*Builder<.*>::whereEnabled\(\).#'
+		- '#Call to an undefined method Illuminate\\Contracts\\Auth\\StatefulGuard::getProvider\(\)#'
+		- '#Dynamic call to static method .*Builder<.*Model>::whereNull\(\).#'
+		- '#Dynamic call to static method .*Builder<.*Model>::whereNotNull\(\).#'
+		- '#Dynamic call to static method Laragear\\WebAuthn\\Http\\Requests\\AssertionRequest::validate\(\).#'

--- a/phpstan/Rules/DisallowedConstructs/DisallowedBooleanCastRule.php
+++ b/phpstan/Rules/DisallowedConstructs/DisallowedBooleanCastRule.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laragear\WebAuthn\PHPStan\Rules\DisallowedConstructs;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Cast\Bool_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Bool_>
+ */
+class DisallowedBooleanCastRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Bool_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            RuleErrorBuilder::message('Cast to bool is forbidden.')->build(),
+        ];
+    }
+}

--- a/phpstan/Rules/DisallowedConstructs/DisallowedBooleanConversionRule.php
+++ b/phpstan/Rules/DisallowedConstructs/DisallowedBooleanConversionRule.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laragear\WebAuthn\PHPStan\Rules\DisallowedConstructs;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+class DisallowedBooleanConversionRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (
+            $node->name->parts !== null &&
+            count($node->name->parts) === 1 && (
+                $node->name->parts[0] === 'boolval' ||
+                $node->name->parts[0] === '\boolval'
+            )
+        ) {
+            return [
+                RuleErrorBuilder::message(
+                    'Conversion to boolean is forbidden.'
+                )->build(),
+            ];
+        } else {
+            return [];
+        }
+    }
+}


### PR DESCRIPTION
# Description

This Pull request enables php stan static code analysis which ensure a stronger code base and resistance to bugs.
Issue #6 is the result of this analysis and would not have been found otherwise.

### Rules applied are the following:

From basic phpstan:

- level 0 :  basic checks, unknown classes, unknown functions, unknown methods called on `$this`, wrong number of arguments passed to those methods and functions, always undefined variables
- level 1 : possibly undefined variables, unknown magic methods and properties on classes with `__call` and `__get`
- level 2 : unknown methods checked on all expressions (not just `$this`), validating PHPDocs
- level 3 : return types, types assigned to properties
- level 4 : basic dead code checking - always false `instanceof` and other type checks, dead `else` branches, unreachable code after return; etc.
- level 5 : checking types of arguments passed to methods and functions
- level 6 : report missing typehints
- level 7 : report partially wrong union types - if you call a method that only exists on some types in a union type, level 7 starts to report that; other possibly incorrect situations

I did not enable level 8 and 9 because they are too restrictive:

- level 8 : report calling methods and accessing properties on nullable types
- level 9 : be strict about the mixed type - the only allowed operation you can do with it is to pass it to another mixed

Additionally the following rules have been added from : https://github.com/phpstan/phpstan-strict-rules

* `==` and `!=` are forbidden in favor of `===` and `!==`
* Require booleans in `if`, `elseif`, ternary operator, after `!`, and on both sides of `&&` and `||`.
* Require numeric operands or arrays in `+` and numeric operands in `-`/`*`/`/`/`**`/`%`.
* Require numeric operand in `$var++`, `$var--`, `++$var`and `--$var`.
* These functions contain a `$strict` parameter for better type safety, it must be set to `true`:
  * `in_array` (3rd parameter)
  * `array_search` (3rd parameter)
  * `array_keys` (3rd parameter; only if the 2nd parameter `$search_value` is provided)
  * `base64_decode` (2nd parameter)
* Variables assigned in `while` loop condition and `for` loop initial assignment cannot be used after the loop.
* Variables set in foreach that's always looped thanks to non-empty arrays cannot be used after the loop.
* Types in `switch` condition and `case` value must match. PHP compares them loosely by default and that can lead to unexpected results.
* Check that statically declared methods are called statically.
* Disallow `empty()` - it's a very loose comparison (see [manual](https://php.net/empty)), it's recommended to use more strict one.
* Disallow short ternary operator (`?:`) - implies weak comparison, it's recommended to use null coalesce operator (`??`) or ternary operator with strict condition.
* Disallow variable variables (`$$foo`, `$this->$method()` etc.)
* Disallow overwriting variables with foreach key and value variables
* Always true `instanceof`, type-checking `is_*` functions and strict comparisons `===`/`!==`. These checks can be turned off by setting `checkAlwaysTrueInstanceof`/`checkAlwaysTrueCheckTypeFunctionCall`/`checkAlwaysTrueStrictComparison` to false.
* Correct case for referenced and called function names.
* Correct case for inherited and implemented method names.
* Contravariance for parameter types and covariance for return types in inherited methods (also known as Liskov substitution principle - LSP)
* Check LSP even for static methods
* Require calling parent constructor
* Disallow usage of backtick operator (`` $ls = `ls -la` ``)
* Closure should use `$this` directly instead of using `$this` variable indirectly

And the following extra:

* Boolean casting is forbidden `boolval()` `(bool) $var`, prefer explicit operation e.g. `$var === ''` for `if($var)` where `$var` is a string.
* Forbid the use of `@` to silence errors
* Verify that there are no unused variables

Feel free to check: https://github.com/ildyria/WebAuthn/runs/7193039501?check_suite_focus=true to skim through the issues.

Do note that this pull request does not include all the code fixes as you asked to see all the ingredients before baking the cake.