### PR TITLE
[1.x] FIX #10 - missing jetbrains/phpstorm-attributes dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,16 +32,17 @@
         "issues": "https://github.com/Laragear/TwoFactor/issues"
     },
     "require": {
-        "php" : ">=8.0.2",
+        "php": ">=8.0.2",
         "ext-openssl": "*",
-        "ext-json" : "*",
+        "ext-json": "*",
         "illuminate/auth": "9.*",
         "illuminate/http": "9.*",
         "illuminate/session": "9.*",
         "illuminate/support": "9.*",
         "illuminate/config": "9.*",
         "illuminate/database": "9.*",
-        "illuminate/encryption": "9.*"
+        "illuminate/encryption": "9.*",
+        "jetbrains/phpstorm-attributes": "^1.0"
     },
     "require-dev": {
         "orchestra/testbench": "7.*",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "illuminate/support": "9.*",
         "illuminate/config": "9.*",
         "illuminate/database": "9.*",
-        "illuminate/encryption": "9.*",
+        "illuminate/encryption": "9.*"
     },
     "require-dev": {
         "orchestra/testbench": "7.*",

--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,12 @@
         "illuminate/config": "9.*",
         "illuminate/database": "9.*",
         "illuminate/encryption": "9.*",
-        "jetbrains/phpstorm-attributes": "^1.0"
     },
     "require-dev": {
         "orchestra/testbench": "7.*",
         "phpunit/phpunit": "^9.5",
-        "mockery/mockery": "^1.5"
+        "mockery/mockery": "^1.5",
+        "jetbrains/phpstorm-attributes": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Description

Fixes #10 

Simply add 
```
        "jetbrains/phpstorm-attributes": "^1.0",
```
in composer.json.