### PR TITLE
[1.x] Fix: support for xcrf token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs
 vendor
 coverage
 .phpunit.result.cache
+.vscode

--- a/resources/js/webauthn.js
+++ b/resources/js/webauthn.js
@@ -72,8 +72,8 @@ class WebAuthn {
         let xsrfToken;
         let csrfToken;
 
-        // If xcsrfToken is not set, we try to fetch it.
         if (xcsrfToken === null) {
+            // If the developer didn't issue an XSRF token, we will find it ourselves.
             xsrfToken = WebAuthn.#XsrfToken;
             csrfToken = WebAuthn.#firstInputWithCsrfToken;
         } else{
@@ -90,7 +90,6 @@ class WebAuthn {
         if (xsrfToken !== null) {
             this.#headers["X-XSRF-TOKEN"] ??= xsrfToken;
         } else if (csrfToken !== null) {
-            // If the developer didn't issue an XSRF token, we will find it ourselves.
             this.#headers["X-CSRF-TOKEN"] ??= csrfToken;
         } else {
             // We didn't find it, and since is required, we will bail out.


### PR DESCRIPTION
Fixes #13 

# Description

- Add method to fetch the XSRF token from the header cookies.
- Rework the logic to differentiate between XSRF and CSRF tokens (differentiating on the length: 40 vs 224).
- Throw error if length of provided token in constructor argument does not match.
- Throw error if no [xc]srf token are found & not provided