### PR TITLE
[1.x] Allow user credential to have id = 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build
 /vendor
 /.idea
+/.vscode
 .php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock

--- a/src/Http/Requests/AssertionRequest.php
+++ b/src/Http/Requests/AssertionRequest.php
@@ -121,7 +121,7 @@ class AssertionRequest extends FormRequest
      */
     protected function findUser(WebAuthnAuthenticatable|array|int|string|null $credentials): ?WebAuthnAuthenticatable
     {
-        if (!$credentials) {
+        if ($credentials === null) {
             return null;
         }
 


### PR DESCRIPTION
# Description

```php
if (!$credentials) {
  return null
}
```
will return `null` if `$credentials` is one of the following: `null`, `0`, `''`.
I strongly believe that it is possible for a `user_id` to be `0` for example.
This check is breaking in such occasion.

This pull request aims to provide a stronger check while respecting the spirit of the code.