### PR TITLE
FIX: relaying_party typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ After that, you will receive the `config/webauthn.php` config file with an array
 <?php
 
 return [
-    'relaying_party' => [
+    'relying_party' => [
         'name' => env('WEBAUTHN_NAME', env('APP_NAME')),
         'id'   => env('WEBAUTHN_ID'),
     ],
@@ -559,18 +559,18 @@ return [
 ];
 ```
 
-### Relaying Party Information
+### Relying Party Information
 
 ```php
 return [
-    'relaying_party' => [
+    'relying_party' => [
         'name' => env('WEBAUTHN_NAME', env('APP_NAME')),
         'id'   => env('WEBAUTHN_ID'),
     ],
 ];
 ```
 
-The _Relaying Party_ is just a way to uniquely identify your application in the user device:
+The _Relying Party_ is just a way to uniquely identify your application in the user device:
 
 * `name`: The name of the application. Defaults to the application name.
 * `id`: An unique ID the application, like the site domain. If `null`, the device may fill it internally, usually as the full domain.

--- a/config/webauthn.php
+++ b/config/webauthn.php
@@ -4,11 +4,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Relaying Party
+    | Relying Party
     |--------------------------------------------------------------------------
     |
     | We will use your application information to inform the device who is the
-    | relaying party. While only the name is enough, you can further set the
+    | relying party. While only the name is enough, you can further set the
     | a custom domain as ID and even an icon image data encoded as BASE64.
     |
     */

--- a/src/Attestation/Validator/Pipes/CheckRelyingPartyHashSame.php
+++ b/src/Attestation/Validator/Pipes/CheckRelyingPartyHashSame.php
@@ -35,6 +35,6 @@ class CheckRelyingPartyHashSame extends BaseCheckRelyingPartyHashSame
      */
     protected function relyingPartyId(AssertionValidation|AttestationValidation $validation): string
     {
-        return $this->config->get('webauthn.relaying_party.id') ?? $this->config->get('app.url');
+        return $this->config->get('webauthn.relying_party.id') ?? $this->config->get('app.url');
     }
 }

--- a/src/Attestation/Validator/Pipes/MakeWebAuthnCredential.php
+++ b/src/Attestation/Validator/Pipes/MakeWebAuthnCredential.php
@@ -41,7 +41,7 @@ class MakeWebAuthnCredential
             'alias' => $validation->request->json('response.alias'),
 
             'counter' => $validation->attestationObject->authenticatorData->counter,
-            'rp_id' => $this->config->get('webauthn.relaying_party.id') ?? $this->config->get('app.url'),
+            'rp_id' => $this->config->get('webauthn.relying_party.id') ?? $this->config->get('app.url'),
             'origin' => $validation->clientDataJson->origin,
             'transports' => $validation->request->json('response.transports'),
             'aaguid' => Uuid::fromBytes($validation->attestationObject->authenticatorData->attestedCredentialData->aaguid),

--- a/src/SharedPipes/CheckRelyingPartyHashSame.php
+++ b/src/SharedPipes/CheckRelyingPartyHashSame.php
@@ -39,11 +39,11 @@ abstract class CheckRelyingPartyHashSame
     public function handle(AttestationValidation|AssertionValidation $validation, Closure $next): mixed
     {
         // This way we can get the app RP ID on attestation, and the Credential RP ID
-        // on assertion. The credential will have the same Relaying Party ID on both
+        // on assertion. The credential will have the same Relying Party ID on both
         // the authenticator and the application so on assertion both should match.
-        $relayingParty = parse_url($this->relyingPartyId($validation), PHP_URL_HOST);
+        $relyingParty = parse_url($this->relyingPartyId($validation), PHP_URL_HOST);
 
-        if ($this->authenticatorData($validation)->hasNotSameRPIdHash($relayingParty)) {
+        if ($this->authenticatorData($validation)->hasNotSameRPIdHash($relyingParty)) {
             static::throw($validation, 'Response has different Relying Party ID hash.');
         }
 

--- a/src/SharedPipes/CheckRelyingPartyIdContained.php
+++ b/src/SharedPipes/CheckRelyingPartyIdContained.php
@@ -40,11 +40,11 @@ abstract class CheckRelyingPartyIdContained
     public function handle(AttestationValidation|AssertionValidation $validation, Closure $next): mixed
     {
         if (!$host = parse_url($validation->clientDataJson->origin, PHP_URL_HOST)) {
-            static::throw($validation, 'Relaying Party ID is invalid.');
+            static::throw($validation, 'Relying Party ID is invalid.');
         }
 
         $current = parse_url(
-            $this->config->get('webauthn.relaying_party.id') ?? $this->config->get('app.url'), PHP_URL_HOST
+            $this->config->get('webauthn.relying_party.id') ?? $this->config->get('app.url'), PHP_URL_HOST
         );
 
         // Check the host is the same or is a subdomain of the current config domain.
@@ -52,6 +52,6 @@ abstract class CheckRelyingPartyIdContained
             return $next($validation);
         }
 
-        static::throw($validation, 'Relaying Party ID not scoped to current.');
+        static::throw($validation, 'Relying Party ID not scoped to current.');
     }
 }

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -457,7 +457,7 @@ class ValidationTest extends TestCase
         $this->request->setJson(new ParameterBag($invalid));
 
         $this->expectException(AssertionException::class);
-        $this->expectExceptionMessage('Assertion Error: Relaying Party ID not scoped to current.');
+        $this->expectExceptionMessage('Assertion Error: Relying Party ID not scoped to current.');
 
         $this->validate();
     }
@@ -477,7 +477,7 @@ class ValidationTest extends TestCase
         $this->request->setJson(new ParameterBag($invalid));
 
         $this->expectException(AssertionException::class);
-        $this->expectExceptionMessage('Assertion Error: Relaying Party ID not scoped to current.');
+        $this->expectExceptionMessage('Assertion Error: Relying Party ID not scoped to current.');
 
         $this->validate();
     }

--- a/tests/Attestation/CreatorTest.php
+++ b/tests/Attestation/CreatorTest.php
@@ -80,7 +80,7 @@ class CreatorTest extends TestCase
             ]);
     }
 
-    public function test_uses_relaying_party_config(): void
+    public function test_uses_relying_party_config(): void
     {
         config(['webauthn.relying_party' => [
             'id' => 'https://foo.bar',

--- a/tests/Attestation/ValidationTest.php
+++ b/tests/Attestation/ValidationTest.php
@@ -504,7 +504,7 @@ class ValidationTest extends TestCase
     public function test_rp_id_fails_if_not_equal(): void
     {
         $this->expectException(AttestationException::class);
-        $this->expectExceptionMessage('Attestation Error: Relaying Party ID not scoped to current.');
+        $this->expectExceptionMessage('Attestation Error: Relying Party ID not scoped to current.');
 
         $invalid = FakeAuthenticator::attestationResponse();
 
@@ -524,7 +524,7 @@ class ValidationTest extends TestCase
     public function test_rp_id_fails_if_not_contained(): void
     {
         $this->expectException(AttestationException::class);
-        $this->expectExceptionMessage('Attestation Error: Relaying Party ID not scoped to current.');
+        $this->expectExceptionMessage('Attestation Error: Relying Party ID not scoped to current.');
 
         $invalid = FakeAuthenticator::attestationResponse();
 
@@ -546,7 +546,7 @@ class ValidationTest extends TestCase
         $this->app->when(CheckRelyingPartyHashSame::class)
             ->needs(ConfigContract::class)
             ->give(static function (): Repository {
-                return tap(new Repository())->set('webauthn.relaying_party.id', 'https://otherhost.com');
+                return tap(new Repository())->set('webauthn.relying_party.id', 'https://otherhost.com');
             });
 
         $this->expectException(AttestationException::class);


### PR DESCRIPTION
# Description

Some instructions use the string `relaying_party`, others use `relying_party`. This causes (at least) a 422 response when the `webauthn.php` config file is published as it declares `relying_party` while the following instruction in [`Laragear\WebAuthn\SharedPipes\CheckRelyingPartyIdContained.php`](https://github.com/Laragear/WebAuthn/blob/7f628f9a7979dc69cf2dc581895030c2b9e493dc/src/SharedPipes/CheckRelyingPartyIdContained.php#L47) waits for `relaying_party`:

```php
$this->config->get('webauthn.relaying_party.id') ?? $this->config->get('app.url'), PHP_URL_HOST
```
