### PR TITLE
[minor] correct publishing the config file not working

### DIFF
--- a/src/WebAuthnServiceProvider.php
+++ b/src/WebAuthnServiceProvider.php
@@ -46,6 +46,7 @@ class WebAuthnServiceProvider extends ServiceProvider
             $this->publishesMigrations(static::MIGRATIONS);
             $this->publishes([static::ROUTES => $this->app->basePath('routes/webauthn.php')], 'routes');
             // @phpstan-ignore-next-line
+            $this->publishes([static::CONFIG => $this->app->configPath('webauthn.php')], 'config');
             $this->publishes([static::CONTROLLERS => $this->app->path('Http/Controllers/WebAuthn')], 'controllers');
             $this->publishes([static::JS => $this->app->resourcePath('js/vendor/webauthn')], 'js');
         }


### PR DESCRIPTION
When Publishing the config file

```shell
php artisan vendor:publish --provider="Laragear\WebAuthn\WebAuthnServiceProvider" --tag="config"
```
It will return

```shell
INFO  No publishable resources for tag [config].
```
**LINE FOR CONFIG WAS MISSING**