### PR TITLE
[1.1.4] FIX: Null to string error when using parse_url on WEBAUTHN_ID

### DIFF
--- a/src/Attestation/Validator/Pipes/CheckRelyingPartyHashSame.php
+++ b/src/Attestation/Validator/Pipes/CheckRelyingPartyHashSame.php
@@ -35,6 +35,7 @@ class CheckRelyingPartyHashSame extends BaseCheckRelyingPartyHashSame
      */
     protected function relyingPartyId(AssertionValidation|AttestationValidation $validation): string
     {
-        return $this->config->get('webauthn.relying_party.id') ?? parse_url($this->config->get('app.url'), PHP_URL_HOST);
+        return $this->config->get('webauthn.relying_party.id')
+            ?? parse_url($this->config->get('app.url'), PHP_URL_HOST);
     }
 }

--- a/src/Attestation/Validator/Pipes/CheckRelyingPartyHashSame.php
+++ b/src/Attestation/Validator/Pipes/CheckRelyingPartyHashSame.php
@@ -35,6 +35,6 @@ class CheckRelyingPartyHashSame extends BaseCheckRelyingPartyHashSame
      */
     protected function relyingPartyId(AssertionValidation|AttestationValidation $validation): string
     {
-        return $this->config->get('webauthn.relying_party.id') ?? $this->config->get('app.url');
+        return $this->config->get('webauthn.relying_party.id') ?? parse_url($this->config->get('app.url'), PHP_URL_HOST);
     }
 }

--- a/src/SharedPipes/CheckRelyingPartyHashSame.php
+++ b/src/SharedPipes/CheckRelyingPartyHashSame.php
@@ -41,7 +41,7 @@ abstract class CheckRelyingPartyHashSame
         // This way we can get the app RP ID on attestation, and the Credential RP ID
         // on assertion. The credential will have the same Relying Party ID on both
         // the authenticator and the application so on assertion both should match.
-        $relyingParty = parse_url($this->relyingPartyId($validation), PHP_URL_HOST);
+        $relyingParty = $this->relyingPartyId($validation);
 
         if ($this->authenticatorData($validation)->hasNotSameRPIdHash($relyingParty)) {
             static::throw($validation, 'Response has different Relying Party ID hash.');

--- a/src/SharedPipes/CheckRelyingPartyIdContained.php
+++ b/src/SharedPipes/CheckRelyingPartyIdContained.php
@@ -43,7 +43,8 @@ abstract class CheckRelyingPartyIdContained
             static::throw($validation, 'Relying Party ID is invalid.');
         }
 
-        $current = $this->config->get('webauthn.relying_party.id') ?? parse_url($this->config->get('app.url'), PHP_URL_HOST);
+        $current = $this->config->get('webauthn.relying_party.id')
+            ?? parse_url($this->config->get('app.url'), PHP_URL_HOST);
 
         // Check the host is the same or is a subdomain of the current config domain.
         if (hash_equals($current, $host) || Str::is("*.$current", $host)) {

--- a/src/SharedPipes/CheckRelyingPartyIdContained.php
+++ b/src/SharedPipes/CheckRelyingPartyIdContained.php
@@ -43,9 +43,7 @@ abstract class CheckRelyingPartyIdContained
             static::throw($validation, 'Relying Party ID is invalid.');
         }
 
-        $current = parse_url(
-            $this->config->get('webauthn.relying_party.id') ?? $this->config->get('app.url'), PHP_URL_HOST
-        );
+        $current = $this->config->get('webauthn.relying_party.id') ?? parse_url($this->config->get('app.url'), PHP_URL_HOST);
 
         // Check the host is the same or is a subdomain of the current config domain.
         if (hash_equals($current, $host) || Str::is("*.$current", $host)) {


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

Assuming WEBAUTHN_ID is set to a domain
```env
WEBAUTHN_ID=example.net
```

The following code snippet from line 42 in `Laragear\WebAuthn\SharedPipes\CheckRelyingPartyIdContained` will always return a host without the URL scheme (expected)

```php
$host = parse_url($validation->clientDataJson->origin, PHP_URL_HOST);
// returns "example.net"
```

However, when the WEBAUTHN_ID env value is set, using `parse_url()` on WEBAUTHN_ID will return null due to the domain not having a URL scheme. This throws a null to string error on `hash_equals()` on line 49 in `Laragear\WebAuthn\SharedPipes\CheckRelyingPartyIdContained`.

```php
$current = parse_url($this->config->get('webauthn.relying_party.id'), PHP_URL_HOST);
// returns null

hash_equals($current, $host);
// throws null to string error
```

This commit removes the use of `parse_url()` on the WEBAUTHN_ID variable in a couple places to resolve the issue.
