### PR TITLE
Update webauthn.js to prevent wrong request urls

### DIFF
--- a/resources/js/webauthn.js
+++ b/resources/js/webauthn.js
@@ -315,6 +315,7 @@ class WebAuthn {
         const publicKeyCredential = this.#parseOutgoingCredentials(credentials);
 
         Object.assign(publicKeyCredential, response);
+        Object.assign(publicKeyCredential, request);
 
         return await this.#fetch(publicKeyCredential, this.#routes.register).then(WebAuthn.#handleResponse);
     }

--- a/resources/js/webauthn.js
+++ b/resources/js/webauthn.js
@@ -156,8 +156,8 @@ class WebAuthn {
      * @returns {Promise<Response>}
      */
     #fetch(data, route, headers = {}) {
-
-        let url = new URL(route, window.location.origin).href;
+        const url = new URL(route, window.location.origin).href;
+        
         return fetch(url, {
             method: "POST",
             credentials: this.#includeCredentials ? "include" : "same-origin",

--- a/resources/js/webauthn.js
+++ b/resources/js/webauthn.js
@@ -156,7 +156,9 @@ class WebAuthn {
      * @returns {Promise<Response>}
      */
     #fetch(data, route, headers = {}) {
-        return fetch(route, {
+
+        let url = new URL(route, window.location.origin).href;
+        return fetch(url, {
             method: "POST",
             credentials: this.#includeCredentials ? "include" : "same-origin",
             redirect: "error",


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

This pull-request fixes an issue when calling `register` or `login` from routes deeper than one directory.

Calling `register` on a page at location `example.com/users/profile` lead to an non-existing route in `#fetch`, resulting in `404`.

That is because `this.#routes.registerOptions` resolves to `webauthn/register/options` which is a relative route
resulting in `example.com/users/webauthn/register/options` rather than `example.com/webauthn/register/options`.

# Code samples

the new `#fetch`-method ensures the routes are always correct and no `404`s occur.

```js
/**
     * Returns a fetch promise to resolve later.
     *
     * @param request {Object}
     * @param route {string}
     * @param headers {{string}}
     * @returns {Promise<Response>}
     */
    #fetch(request, route, headers = {}) {

        let url = new URL(route, window.location.origin).href;
        return fetch(url, {
            method: "POST",
            credentials: this.#includeCredentials ? "include" : "same-origin",
            redirect: "error",
            headers: {...this.#headers, ...headers},
            body: JSON.stringify(request)
        });
    }
```
