### PR TITLE
[1.x] Encourages new WebAuthn JS helper.

### DIFF
--- a/resources/js/webauthn.js
+++ b/resources/js/webauthn.js
@@ -22,6 +22,10 @@
  * SOFTWARE.
  */
 
+/**
+ * @deprecated Use Webpass instead
+ * @see https://github.com/Laragear/webpass
+ */
 class WebAuthn {
     /**
      * Routes for WebAuthn assertion (login) and attestation (register).


### PR DESCRIPTION
# What?

This PR sunsets the `webathun.js` helper for something the simplier and flexible [Webpass](https://github.com/Laragear/webpass).

The helper will be still available for the 1.x version of the package, but no support will be given for that file. Expect version 2.x to not include at all.