### PR TITLE
[3.x] Native Android and iOS implementation integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,8 @@ return [
         'timeout' => 60,
         'key' => '_webauthn',
     ],
-    'additional_allowed_origins' => explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS', '')),
+    'additional_allowed_origins' => ! empty(env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS')) ?
+        explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS')) : [],
 ];
 ```
 
@@ -733,7 +734,8 @@ The outgoing challenges are random string of bytes. This controls how many bytes
 
 ```php
 return [
-    'additional_allowed_origins' => explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS', '')),
+    'additional_allowed_origins' => ! empty(env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS')) ?
+        explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS')) : [],
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -683,7 +683,8 @@ return [
         'bytes' => 16,
         'timeout' => 60,
         'key' => '_webauthn',
-    ]
+    ],
+    'additional_allowed_origins' => explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS', '')),
 ];
 ```
 
@@ -727,6 +728,17 @@ return [
 ```
 
 The outgoing challenges are random string of bytes. This controls how many bytes, the seconds which the challenge is valid, and the session key used to store the challenge while its being resolved by the device.
+
+### Origins
+
+```php
+return [
+    'additional_allowed_origins' => explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS', '')),
+];
+```
+
+The _additional_allowed_origins_ allows the extension of the allowed origins, useful in case of mobile native implementation (especially android).
+
 
 ## Laravel UI, Jetstream, Fortify, Sanctum, Breeze, Inertia and Livewire
 

--- a/config/webauthn.php
+++ b/config/webauthn.php
@@ -36,4 +36,16 @@ return [
         'timeout' => 60,
         'key' => '_webauthn',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Origins
+    |--------------------------------------------------------------------------
+    |
+    | This option allows the extension of the allowed origins, useful in case
+    | of mobile native implementation (especially android).
+    |
+    */
+
+    'additional_allowed_origins' => explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS', '')),
 ];

--- a/config/webauthn.php
+++ b/config/webauthn.php
@@ -47,5 +47,6 @@ return [
     |
     */
 
-    'additional_allowed_origins' => explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS', '')),
+    'additional_allowed_origins' => ! empty(env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS')) ?
+        explode(',', env('WEBAUTHN_ADDITIONAL_ALLOWED_ORIGINS')) : [],
 ];

--- a/src/Assertion/Creator/Pipes/AddConfiguration.php
+++ b/src/Assertion/Creator/Pipes/AddConfiguration.php
@@ -23,6 +23,10 @@ class AddConfiguration
     {
         $assertion->json->set('timeout', $this->config->get('webauthn.challenge.timeout') * 1000);
 
+        if ($id = $this->config->get('webauthn.relying_party.id')) {
+            $assertion->json->set('rpId', $id);
+        }
+
         return $next($assertion);
     }
 }

--- a/src/SharedPipes/CheckOriginSecure.php
+++ b/src/SharedPipes/CheckOriginSecure.php
@@ -30,6 +30,12 @@ abstract class CheckOriginSecure
             static::throw($validation, 'Response has an empty origin.');
         }
 
+        $additionalAllowedOrigins = $this->config->get('webauthn.additional_allowed_origins');
+
+        if (is_array($additionalAllowedOrigins) && in_array($validation->clientDataJson->origin, $additionalAllowedOrigins)) {
+            return $next($validation);
+        }
+
         $origin = parse_url($validation->clientDataJson->origin);
 
         if (! $origin || ! isset($origin['host'], $origin['scheme'])) {

--- a/src/SharedPipes/CheckRelyingPartyIdContained.php
+++ b/src/SharedPipes/CheckRelyingPartyIdContained.php
@@ -36,6 +36,12 @@ abstract class CheckRelyingPartyIdContained
      */
     public function handle(AttestationValidation|AssertionValidation $validation, Closure $next): mixed
     {
+        $additionalAllowedOrigins = $this->config->get('webauthn.additional_allowed_origins');
+
+        if (is_array($additionalAllowedOrigins) && in_array($validation->clientDataJson->origin, $additionalAllowedOrigins)) {
+            return $next($validation);
+        }
+
         if (! $host = parse_url($validation->clientDataJson->origin, PHP_URL_HOST)) {
             static::throw($validation, 'Relying Party ID is invalid.');
         }

--- a/tests/Assertion/CreatorTest.php
+++ b/tests/Assertion/CreatorTest.php
@@ -202,4 +202,16 @@ class CreatorTest extends DatabaseTestCase
                 return $challenge->data->hashEqual('1');
             });
     }
+
+    public function test_uses_config_relying_party_id(): void
+    {
+        $rpId = 'foo.bar';
+
+        config(['webauthn.relying_party.id' => $rpId]);
+
+        $this->response()
+            ->assertJson([
+                'rpId' => $rpId,
+            ]);
+    }
 }

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Event;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidation;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidator;
 use Laragear\WebAuthn\Assertion\Validator\Pipes\CheckPublicKeyCounterCorrect;
-use Laragear\WebAuthn\Assertion\Validator\Pipes\CheckPublicKeySignature;
 use Laragear\WebAuthn\Assertion\Validator\Pipes\CheckUserInteraction;
 use Laragear\WebAuthn\Attestation\AuthenticatorData;
 use Laragear\WebAuthn\ByteBuffer;
@@ -23,7 +22,6 @@ use Laragear\WebAuthn\Exceptions\AssertionException;
 use Laragear\WebAuthn\JsonTransport;
 use Laragear\WebAuthn\Models\WebAuthnCredential;
 use Mockery;
-use Mockery\MockInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Tests\DatabaseTestCase;
@@ -497,7 +495,7 @@ class ValidationTest extends DatabaseTestCase
 
     public function test_check_origin_pass_if_in_additional_allowed_origins(): void
     {
-        $origin = 'android:apk-key-hash:fake';
+        $origin = 'android:';
 
         config(['webauthn.additional_allowed_origins' => [$origin]]);
 

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -497,7 +497,7 @@ class ValidationTest extends DatabaseTestCase
 
     public function test_check_origin_pass_if_in_additional_allowed_origins(): void
     {
-        $origin = 'android:apk-key-fake';
+        $origin = 'android:apk-key-hash:fake';
 
         config(['webauthn.additional_allowed_origins' => [$origin]]);
 
@@ -510,9 +510,6 @@ class ValidationTest extends DatabaseTestCase
         );
 
         $this->validation->json = new JsonTransport($valid);
-
-        // note: in order to reuse FakeAuthenticator we mock CheckPublicKeySignature@validateWithOpenSsl method
-        $this->partialMock(CheckPublicKeySignature::class, fn (MockInterface $mock) => $mock->shouldAllowMockingProtectedMethods()->shouldReceive('validateWithOpenSsl'));
 
         $this->validate();
 

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Event;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidation;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidator;
 use Laragear\WebAuthn\Assertion\Validator\Pipes\CheckPublicKeyCounterCorrect;
+use Laragear\WebAuthn\Assertion\Validator\Pipes\CheckPublicKeySignature;
 use Laragear\WebAuthn\Assertion\Validator\Pipes\CheckUserInteraction;
 use Laragear\WebAuthn\Attestation\AuthenticatorData;
 use Laragear\WebAuthn\ByteBuffer;
@@ -22,6 +23,7 @@ use Laragear\WebAuthn\Exceptions\AssertionException;
 use Laragear\WebAuthn\JsonTransport;
 use Laragear\WebAuthn\Models\WebAuthnCredential;
 use Mockery;
+use Mockery\MockInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Tests\DatabaseTestCase;
@@ -508,6 +510,9 @@ class ValidationTest extends DatabaseTestCase
         );
 
         $this->validation->json = new JsonTransport($valid);
+
+        // note: avoid AssertionException (invalid signature)
+        $this->partialMock(CheckPublicKeySignature::class, fn (MockInterface $mock) => $mock->shouldAllowMockingProtectedMethods()->shouldReceive('validateWithOpenSsl'));
 
         $this->validate();
 

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -495,7 +495,7 @@ class ValidationTest extends DatabaseTestCase
 
     public function test_check_origin_pass_if_in_additional_allowed_origins(): void
     {
-        $origin = 'android:';
+        $origin = 'android:apk-key-hash:hlbf0LpDSuQ3UpvvmFAMc1OhrD96549OYYOkGJKxJVs';
 
         config(['webauthn.additional_allowed_origins' => [$origin]]);
 

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -493,6 +493,27 @@ class ValidationTest extends DatabaseTestCase
         $this->validate();
     }
 
+    public function test_check_origin_pass_if_in_additional_allowed_origins(): void
+    {
+        $origin = 'android:apk-key-fake';
+
+        config(['webauthn.additional_allowed_origins' => [$origin]]);
+
+        $valid = FakeAuthenticator::assertionResponse();
+
+        $valid['response']['clientDataJSON'] = base64_encode(
+            json_encode([
+                'type' => 'webauthn.get', 'origin' => $origin, 'challenge' => FakeAuthenticator::ASSERTION_CHALLENGE,
+            ])
+        );
+
+        $this->validation->json = new JsonTransport($valid);
+
+        $this->expectNotToPerformAssertions();
+
+        $this->validate();
+    }
+
     public function test_rp_id_fails_if_empty(): void
     {
         $invalid = FakeAuthenticator::assertionResponse();

--- a/tests/Attestation/ValidationTest.php
+++ b/tests/Attestation/ValidationTest.php
@@ -532,6 +532,11 @@ class ValidationTest extends DatabaseTestCase
         $this->validate();
     }
 
+    public function test_check_origin_pass_if_in_additional_allowed_origins(): void
+    {
+        $this->markTestIncomplete();
+    }
+
     public function test_rp_id_fails_if_empty(): void
     {
         $invalid = FakeAuthenticator::attestationResponse();

--- a/tests/Attestation/ValidationTest.php
+++ b/tests/Attestation/ValidationTest.php
@@ -534,7 +534,7 @@ class ValidationTest extends DatabaseTestCase
 
     public function test_check_origin_pass_if_in_additional_allowed_origins(): void
     {
-        $origin = 'android:apk-key-fake';
+        $origin = 'android:apk-key-hash:hlbf0LpDSuQ3UpvvmFAMc1OhrD96549OYYOkGJKxJVs';
 
         config(['webauthn.additional_allowed_origins' => [$origin]]);
 

--- a/tests/Attestation/ValidationTest.php
+++ b/tests/Attestation/ValidationTest.php
@@ -534,7 +534,24 @@ class ValidationTest extends DatabaseTestCase
 
     public function test_check_origin_pass_if_in_additional_allowed_origins(): void
     {
-        $this->markTestIncomplete();
+        $origin = 'android:apk-key-fake';
+
+        config(['webauthn.additional_allowed_origins' => [$origin]]);
+
+        $valid = FakeAuthenticator::attestationResponse();
+
+        $valid['response']['clientDataJSON'] = base64_encode(
+            json_encode([
+                'type' => 'webauthn.create', 'origin' => $origin,
+                'challenge' => FakeAuthenticator::ATTESTATION_CHALLENGE,
+            ])
+        );
+
+        $this->validation->json = new JsonTransport($valid);
+
+        $this->validate();
+
+        $this->expectNotToPerformAssertions();
     }
 
     public function test_rp_id_fails_if_empty(): void


### PR DESCRIPTION
# Description

resolve #82 

@DarkGhostHunter can u help me with tests? 
See the test fails `Tests\Assertion\ValidationTest@test_check_origin_pass_if_in_additional_allowed_origins` 
it throw `Laragear\WebAuthn\Exceptions\AssertionException: Assertion Error: Signature is invalid: error:0480006C:PEM routines::no`

Otherwise when I have a little more time I'll try to finalize (I have to better understand the logic of the FakeAuthenticator)

Feel free to adapt the code if necessary as more valid for the style of the library.
