### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ use Laragear\WebAuthn\Http\Routes as WebAuthnRoutes;
 Route::view('welcome');
 
 // WebAuthn Routes
-WebAuthnRoutes::register()->withoutMiddleware(VerifyCsrfToken::class);
+Route::withoutMiddleware([VerifyCsrfToken::class])->group(function () {
+    WebAuthnRoutes::register();
+});
 ```
 
 > [!TIP]


### PR DESCRIPTION
Fix the withouMiddleware call. The middleware is not excluded when doing
```php
WebAuthnRoutes::register()->withoutMiddleware(VerifyCsrfToken::class);
```
