### PR TITLE
[3.x] Fixes Challenge expiration type return

### DIFF
--- a/src/Challenge/Challenge.php
+++ b/src/Challenge/Challenge.php
@@ -2,7 +2,7 @@
 
 namespace Laragear\WebAuthn\Challenge;
 
-use Illuminate\Support\Carbon;
+use DateTimeInterface;
 use Illuminate\Support\Facades\Date;
 use Laragear\WebAuthn\ByteBuffer;
 
@@ -22,9 +22,9 @@ class Challenge
     }
 
     /**
-     * Returns the expiration time as a Carbon instance.
+     * Returns the expiration time as a DateTime interface instance.
      */
-    public function expiresAt(): Carbon
+    public function expiresAt(): DateTimeInterface
     {
         return Date::createFromTimestamp($this->expiresAt);
     }


### PR DESCRIPTION
Fixes #85, where the developer can returns any time library object. Instead of abiding to Carbon, we can just return anything that abides to `DateTimeInterface`.