### PR TITLE
[3.x] Fixes userHandle UUID not being normalized

### DIFF
--- a/src/Assertion/Validator/Pipes/CheckCredentialIsForUser.php
+++ b/src/Assertion/Validator/Pipes/CheckCredentialIsForUser.php
@@ -7,6 +7,7 @@ use Laragear\WebAuthn\Assertion\Validator\AssertionValidation;
 use Laragear\WebAuthn\Exceptions\AssertionException;
 use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\Uuid;
+
 use function hash_equals;
 
 /**

--- a/src/Assertion/Validator/Pipes/CheckCredentialIsForUser.php
+++ b/src/Assertion/Validator/Pipes/CheckCredentialIsForUser.php
@@ -5,8 +5,8 @@ namespace Laragear\WebAuthn\Assertion\Validator\Pipes;
 use Closure;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidation;
 use Laragear\WebAuthn\Exceptions\AssertionException;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\Uuid;
-
 use function hash_equals;
 
 /**
@@ -62,9 +62,16 @@ class CheckCredentialIsForUser
      */
     protected function validateId(AssertionValidation $validation): void
     {
-        $handle = $validation->json->get('response.userHandle');
+        // This try-catch block tries to decode the UUID from the "userHandle" response
+        // of the authenticator, which is pushed from the application to be saved. If
+        // the userHandle cannot be decoded and normalized, then surely is invalid.
+        try {
+            $handle = Uuid::fromString($validation->json->get('response.userHandle'))->getHex()->toString();
+        } catch (InvalidUuidStringException) {
+            throw AssertionException::make('The userHandle is not a valid hexadecimal UUID (32/36 characters).');
+        }
 
-        if (! $handle || ! hash_equals(Uuid::fromString($validation->credential->user_id)->getHex()->toString(), $handle)) {
+        if (! hash_equals(Uuid::fromString($validation->credential->user_id)->getHex()->toString(), $handle)) {
             throw AssertionException::make('User ID is not owner of the stored credential.');
         }
     }

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -28,7 +28,6 @@ use Tests\DatabaseTestCase;
 use Tests\FakeAuthenticator;
 use Tests\Stubs\WebAuthnAuthenticatableUser;
 use Throwable;
-
 use function base64_decode;
 use function base64_encode;
 use function json_encode;
@@ -258,7 +257,25 @@ class ValidationTest extends DatabaseTestCase
         $this->validate();
     }
 
-    public function test_credential_check_if_not_for_user_id(): void
+    public function test_credential_check_is_malformed_user_handle(): void
+    {
+        $assertionResponse = FakeAuthenticator::assertionResponse();
+
+        $assertionResponse['response']['userHandle'] = 'ggggggggggggggggggggggggggggggg';
+
+        $this->validation->json = new JsonTransport($assertionResponse);
+
+        $this->validation->user = WebAuthnAuthenticatableUser::query()->first();
+
+        $this->expectException(AssertionException::class);
+        $this->expectExceptionMessage(
+            'Assertion Error: The userHandle is not a valid hexadecimal UUID (32/36 characters).'
+        );
+
+        $this->validator->send($this->validation)->thenReturn();
+    }
+
+    public function test_credential_check_is_not_for_user_id(): void
     {
         DB::table('webauthn_credentials')->where('id', FakeAuthenticator::CREDENTIAL_ID)->update([
             'user_id' => '4bde1e58dba94de4ab307f46611165cb',

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -28,6 +28,7 @@ use Tests\DatabaseTestCase;
 use Tests\FakeAuthenticator;
 use Tests\Stubs\WebAuthnAuthenticatableUser;
 use Throwable;
+
 use function base64_decode;
 use function base64_encode;
 use function json_encode;


### PR DESCRIPTION
Fixes #83

This is done by detecting if the userHandle is an UUID hexadecimal string of 32 or 36 (with slashes) characters.  If it's not, then the check fails as this library only accepts UUIDs.