### PR TITLE
[3.x] Fix: Retrieve Challenge pipeline

### DIFF
--- a/src/SharedPipes/RetrieveChallenge.php
+++ b/src/SharedPipes/RetrieveChallenge.php
@@ -29,7 +29,7 @@ abstract class RetrieveChallenge
      */
     public function handle(AttestationValidation|AssertionValidation $validation, Closure $next): mixed
     {
-        if ($validation->challenge = $this->challenge->pull($validation)) {
+        if ($validation->challenge == $this->challenge->pull($validation)) {
             return $next($validation);
         }
 


### PR DESCRIPTION
This fixes an issue in the RetrieveChallenge.php where challenge validation always failed

<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

This fix allows the `retrieve challenge` pipeline to correctly compare the challenge

# Code samples

```php
  /**
     * Handle the incoming Assertion Validation.
     */
    public function handle(AttestationValidation|AssertionValidation $validation, Closure $next): mixed
    {
        if ($validation->challenge == $this->challenge->pull($validation)) {
            return $next($validation);
        }

        static::throw($validation, 'Challenge does not exist.');
    }
```
