### PR TITLE
[3.x] FIX: userHandle compatibility between webauthn.js and Webpass

### DIFF
--- a/src/Attestation/Creator/Pipes/AddUserDescriptor.php
+++ b/src/Attestation/Creator/Pipes/AddUserDescriptor.php
@@ -4,6 +4,7 @@ namespace Laragear\WebAuthn\Attestation\Creator\Pipes;
 
 use Closure;
 use Laragear\WebAuthn\Attestation\Creator\AttestationCreation;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @internal
@@ -19,7 +20,7 @@ class AddUserDescriptor
         $existingId = $attestable->user->webAuthnCredentials()->getQuery()->value('user_id');
 
         $attestable->json->set('user', [
-            'id' => $existingId ?: $attestable->user->webAuthnId()->getHex()->toString(),
+            'id' => ($existingId ? Uuid::fromString($existingId) : $attestable->user->webAuthnId())->getHex()->toString(),
             ...$attestable->user->webAuthnData(),
         ]);
 

--- a/tests/Assertion/ValidationTest.php
+++ b/tests/Assertion/ValidationTest.php
@@ -277,6 +277,19 @@ class ValidationTest extends DatabaseTestCase
         $this->validator->send($this->validation)->thenReturn();
     }
 
+    public function test_credential_check_base64_user_handle(): void
+    {
+        $assertionResponse = FakeAuthenticator::assertionResponse();
+
+        $assertionResponse['response']['userHandle'] = base64_encode($assertionResponse['response']['userHandle']);
+
+        $this->validation->json = new JsonTransport($assertionResponse);
+
+        $this->validation->user = WebAuthnAuthenticatableUser::query()->first();
+
+        static::assertInstanceOf(AssertionValidation::class, $this->validator->send($this->validation)->thenReturn());
+    }
+
     public function test_credential_check_is_not_for_user_id(): void
     {
         DB::table('webauthn_credentials')->where('id', FakeAuthenticator::CREDENTIAL_ID)->update([

--- a/tests/Attestation/CreatorTest.php
+++ b/tests/Attestation/CreatorTest.php
@@ -170,7 +170,7 @@ class CreatorTest extends DatabaseTestCase
         ])->save();
 
         $this->response()
-            ->assertJsonPath('user.id', $uuid->toString());
+            ->assertJsonPath('user.id', $uuid->getHex()->toString());
     }
 
     public function test_adds_existing_credentials_if_unique_by_default(): void


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

This fixes two bugs with compatibility of the userHandle parameter between the now-deprecated webauthn.js library and Webpass that I encountered when trying to upgrade my app from webauthn.js to Webpass. May be related to Laragear/webpass#16.

In order to clear the pathway for migration to Webpass, Webpass must also be updated to use SimpleWebAuthn/browser v10. I believe this should be a drop-in upgrade as the only change in that version is the handling of userHandle.

This update is now in https://github.com/Laragear/webpass/pull/18 and passes tests with no other changes as expected.

# Details

The first fix is to normalise the `user_id` retrieved from the DB when a user creates additional credentials. Since #90 this is not strictly required, however not normalising this value does cause an issue with the old webpass.js, and more than that, it's nice to be consistent.

The second fix will retain compatibility with credentials created with current versions of Webpass after it is updated to use SimpleWebAuthn v10. The old webauthn.js and SWA v10 use base64url on the userHandle and so are compatible, whereas SWA v9 uses TextEncoder, which just requires an additional base64 decode on the server side to obtain the original userHandle.