### PR TITLE
[3.x] User Provider: Do not access rehash function in L10

### DIFF
--- a/src/Auth/WebAuthnUserProvider.php
+++ b/src/Auth/WebAuthnUserProvider.php
@@ -123,7 +123,7 @@ class WebAuthnUserProvider extends EloquentUserProvider
      */
     public function rehashPasswordIfRequired(UserContract $user, array $credentials, bool $force = false): void
     {
-        if (! $this->isSignedChallenge($credentials)) {
+        if (! $this->isSignedChallenge($credentials) && method_exists(get_parent_class($this), 'rehashPasswordIfRequired')) {
             parent::rehashPasswordIfRequired($user, $credentials, $force);
         }
     }


### PR DESCRIPTION
This function was added in Laravel 11.
Currently, this causes an exception when using Fortify with 2FA and Laravel 10 together with WebAuthn.

In Fortify the function is called when it detects that it exists, for compatibility with Laravel 10. But since we implement this function in WebAuthn, we need to also add a check if this actually exists on the parent class.

So in Laravel 10 we will just ignore the function and do nothing. This should be a sufficient workaround to support both.

Tested this in a Laravel 10 project and also tested that it will still call the parent function once defined.

Thanks for your work!