### PR TITLE
[4.x]: Offer an ability to override the user provider query

### DIFF
--- a/config/webauthn.php
+++ b/config/webauthn.php
@@ -53,5 +53,5 @@ return [
         'key' => '_webauthn',
     ],
 
-    'credential_resolver' => [DefaultCredentialResolver::class, 'resolveWebAuthnCredentials']
+    'credential_resolver' => [DefaultCredentialResolver::class, 'resolveWebAuthnCredentials'],
 ];

--- a/config/webauthn.php
+++ b/config/webauthn.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laragear\WebAuthn\Auth\DefaultCredentialResolver;
+
 return [
 
     /*
@@ -50,4 +52,6 @@ return [
         'timeout' => 60,
         'key' => '_webauthn',
     ],
+
+    'credential_resolver' => [DefaultCredentialResolver::class, 'resolveWebAuthnCredentials']
 ];

--- a/src/Auth/DefaultCredentialResolver.php
+++ b/src/Auth/DefaultCredentialResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laragear\WebAuthn\Auth;
+
+use Closure;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+
+class DefaultCredentialResolver
+{
+    public static function resolveWebAuthnCredentials(string $keyId): Closure
+    {
+        return static function (Builder $query) use ($keyId): void {
+            $query->whereHas('webAuthnCredentials', static function (Builder $query) use ($keyId): void {
+                // @phpstan-ignore-next-line
+                $query->whereKey($keyId)->whereEnabled();
+            });
+        };
+    }
+}

--- a/src/Auth/WebAuthnUserProvider.php
+++ b/src/Auth/WebAuthnUserProvider.php
@@ -5,7 +5,6 @@ namespace Laragear\WebAuthn\Auth;
 use Closure;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
-use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidation;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidator;
@@ -25,8 +24,6 @@ use function logger;
  */
 class WebAuthnUserProvider extends EloquentUserProvider
 {
-    protected ?Closure $webAuthnCredentialResolver = null;
-
     /**
      * Create a new database user provider.
      */
@@ -35,6 +32,7 @@ class WebAuthnUserProvider extends EloquentUserProvider
         string $model,
         protected AssertionValidator $validator,
         protected bool $fallback,
+        protected Closure $webAuthnCredentialResolver
     ) {
         parent::__construct($hasher, $model);
     }
@@ -54,7 +52,7 @@ class WebAuthnUserProvider extends EloquentUserProvider
 
             unset($credentials['id'], $credentials['rawId'], $credentials['response'], $credentials['type']);
 
-            $credentials = [...$credentials, $this->webAuthnCredentialsResolver($id)];
+            $credentials = [...$credentials, call_user_func($this->webAuthnCredentialResolver, $id)];
         }
 
         return parent::retrieveByCredentials($credentials);
@@ -125,22 +123,5 @@ class WebAuthnUserProvider extends EloquentUserProvider
         if (! $this->isSignedChallenge($credentials) && method_exists(get_parent_class($this), 'rehashPasswordIfRequired')) {
             parent::rehashPasswordIfRequired($user, $credentials, $force);
         }
-    }
-
-    public function resolveWebAuthnCredentialsWith(Closure $resolver): void
-    {
-        $this->webAuthnCredentialResolver = $resolver;
-    }
-
-    protected function webAuthnCredentialsResolver(string $id): Closure
-    {
-        return $this->webAuthnCredentialResolver
-            ? call_user_func($this->webAuthnCredentialResolver, $id)
-            : static function (Builder $query) use ($id): void {
-                $query->whereHas('webAuthnCredentials', static function (Builder $query) use ($id): void {
-                    // @phpstan-ignore-next-line
-                    $query->whereKey($id)->whereEnabled();
-                });
-            };
     }
 }

--- a/src/Auth/WebAuthnUserProvider.php
+++ b/src/Auth/WebAuthnUserProvider.php
@@ -141,6 +141,6 @@ class WebAuthnUserProvider extends EloquentUserProvider
                     // @phpstan-ignore-next-line
                     $query->whereKey($id)->whereEnabled();
                 });
-        };
+            };
     }
 }

--- a/src/Auth/WebAuthnUserProvider.php
+++ b/src/Auth/WebAuthnUserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laragear\WebAuthn\Auth;
 
+use Closure;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 use Illuminate\Contracts\Database\Eloquent\Builder;
@@ -24,6 +25,8 @@ use function logger;
  */
 class WebAuthnUserProvider extends EloquentUserProvider
 {
+    protected ?Closure $webAuthnCredentialResolver = null;
+
     /**
      * Create a new database user provider.
      */
@@ -51,12 +54,7 @@ class WebAuthnUserProvider extends EloquentUserProvider
 
             unset($credentials['id'], $credentials['rawId'], $credentials['response'], $credentials['type']);
 
-            $credentials = [...$credentials, static function (Builder $query) use ($id): void {
-                $query->whereHas('webAuthnCredentials', static function (Builder $query) use ($id): void {
-                    // @phpstan-ignore-next-line
-                    $query->whereKey($id)->whereEnabled();
-                });
-            }];
+            $credentials = [...$credentials, $this->webAuthnCredentialsResolver($id)];
         }
 
         return parent::retrieveByCredentials($credentials);
@@ -127,5 +125,22 @@ class WebAuthnUserProvider extends EloquentUserProvider
         if (! $this->isSignedChallenge($credentials) && method_exists(get_parent_class($this), 'rehashPasswordIfRequired')) {
             parent::rehashPasswordIfRequired($user, $credentials, $force);
         }
+    }
+
+    public function resolveWebAuthnCredentialsWith(Closure $resolver): void
+    {
+        $this->webAuthnCredentialResolver = $resolver;
+    }
+
+    protected function webAuthnCredentialsResolver(string $id): Closure
+    {
+        return $this->webAuthnCredentialResolver
+            ? call_user_func($this->webAuthnCredentialResolver, $id)
+            : static function (Builder $query) use ($id): void {
+                $query->whereHas('webAuthnCredentials', static function (Builder $query) use ($id): void {
+                    // @phpstan-ignore-next-line
+                    $query->whereKey($id)->whereEnabled();
+                });
+        };
     }
 }

--- a/src/WebAuthnServiceProvider.php
+++ b/src/WebAuthnServiceProvider.php
@@ -104,6 +104,7 @@ class WebAuthnServiceProvider extends ServiceProvider
                         $config['model'],
                         $app->make(Assertion\Validator\AssertionValidator::class),
                         $config['password_fallback'] ?? true,
+                        ($app['config']['webauthn.credential_resolver'])(...),
                     );
                 }
             );

--- a/tests/Auth/EloquentWebAuthnProviderTest.php
+++ b/tests/Auth/EloquentWebAuthnProviderTest.php
@@ -4,8 +4,6 @@
 
 namespace Tests\Auth;
 
-use Tests\Stubs\NullCredentialResolver;
-use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidator;
 use Laragear\WebAuthn\Exceptions\AssertionException;
@@ -15,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use Tests\DatabaseTestCase;
 use Tests\FakeAuthenticator;
+use Tests\Stubs\NullCredentialResolver;
 use Tests\Stubs\WebAuthnAuthenticatableUser;
 
 class EloquentWebAuthnProviderTest extends DatabaseTestCase

--- a/tests/Auth/EloquentWebAuthnProviderTest.php
+++ b/tests/Auth/EloquentWebAuthnProviderTest.php
@@ -4,6 +4,7 @@
 
 namespace Tests\Auth;
 
+use Tests\Stubs\NullCredentialResolver;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidator;
@@ -82,7 +83,8 @@ class EloquentWebAuthnProviderTest extends DatabaseTestCase
 
         static::assertTrue(WebAuthnAuthenticatableUser::query()->first()->is($retrieved));
 
-        $provider->resolveWebAuthnCredentialsWith(fn (string $id) => fn (Builder $query) => $query->whereNull('id'));
+        $this->app->make('config')->set('webauthn.credential_resolver', [NullCredentialResolver::class, 'resolveWebAuthnCredentials']);
+        $provider = Auth::createUserProvider('users');
 
         $retrieved = $provider->retrieveByCredentials([
             'id' => FakeAuthenticator::CREDENTIAL_ID,

--- a/tests/Auth/EloquentWebAuthnProviderTest.php
+++ b/tests/Auth/EloquentWebAuthnProviderTest.php
@@ -5,6 +5,7 @@
 namespace Tests\Auth;
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidator;
 use Laragear\WebAuthn\Exceptions\AssertionException;
 use Laragear\WebAuthn\Models\WebAuthnCredential;
@@ -60,6 +61,31 @@ class EloquentWebAuthnProviderTest extends DatabaseTestCase
 
         $retrieved = $provider->retrieveByCredentials([
             'id' => '27EdS6eTDHCTa9Y73G9gY1b81yVJuuiu1TTyorFicBf',
+            'rawId' => 'raw',
+            'response' => ['something'],
+            'type' => 'public-key',
+        ]);
+
+        static::assertNull($retrieved);
+    }
+
+    public function test_custom_webauthn_resolver(): void
+    {
+        $provider = Auth::createUserProvider('users');
+
+        $retrieved = $provider->retrieveByCredentials([
+            'id' => FakeAuthenticator::CREDENTIAL_ID,
+            'rawId' => 'raw',
+            'response' => ['something'],
+            'type' => 'public-key',
+        ]);
+
+        static::assertTrue(WebAuthnAuthenticatableUser::query()->first()->is($retrieved));
+
+        $provider->resolveWebAuthnCredentialsWith(fn (string $id) => fn(Builder $query) => $query->whereNull('id'));
+
+        $retrieved = $provider->retrieveByCredentials([
+            'id' => FakeAuthenticator::CREDENTIAL_ID,
             'rawId' => 'raw',
             'response' => ['something'],
             'type' => 'public-key',

--- a/tests/Auth/EloquentWebAuthnProviderTest.php
+++ b/tests/Auth/EloquentWebAuthnProviderTest.php
@@ -4,8 +4,8 @@
 
 namespace Tests\Auth;
 
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 use Laragear\WebAuthn\Assertion\Validator\AssertionValidator;
 use Laragear\WebAuthn\Exceptions\AssertionException;
 use Laragear\WebAuthn\Models\WebAuthnCredential;
@@ -82,7 +82,7 @@ class EloquentWebAuthnProviderTest extends DatabaseTestCase
 
         static::assertTrue(WebAuthnAuthenticatableUser::query()->first()->is($retrieved));
 
-        $provider->resolveWebAuthnCredentialsWith(fn (string $id) => fn(Builder $query) => $query->whereNull('id'));
+        $provider->resolveWebAuthnCredentialsWith(fn (string $id) => fn (Builder $query) => $query->whereNull('id'));
 
         $retrieved = $provider->retrieveByCredentials([
             'id' => FakeAuthenticator::CREDENTIAL_ID,

--- a/tests/Stubs/NullCredentialResolver.php
+++ b/tests/Stubs/NullCredentialResolver.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Tests\Stubs;
 

--- a/tests/Stubs/NullCredentialResolver.php
+++ b/tests/Stubs/NullCredentialResolver.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Stubs;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+
+final class NullCredentialResolver
+{
+    public static function resolveWebAuthnCredentials(): Closure
+    {
+        return fn (Builder $query) => $query->whereNull('id');
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

This feature offers the ability for the developer to override the credential resolving query.
This is useful when the authenticable user is on a different database to the credentials - the `whereHas` method in Laravel doesn't work in this scenario.

# Code samples

```php
// config/webauthn.php

return [
    // ...
    
    'credential_provider' => [WebAuthnCredentialResolver::class, 'resolveWebAuthnCredentials'],
];

// Resolver

class WebAuthnCredentialResolver
{
    public static function resolveWebAuthnCredentials(string $keyId): Closure
    {
        return fn (Builder $query) => $query->whereExists(
            function ($query) use ($keyId) {
                $query->fromSub(
                    WebAuthnCredential::select(\DB::raw(1))
                        ->whereKey($keyId)
                        ->where('authenticatable_type', User::class)
                        ->whereColumn('webauthn_credentials.authenticatable_id', 'users.id')
                        ->whereEnabled(),
                    'webauthn_check',
                );
            }
        );
    }
}

```
